### PR TITLE
Improve detracción fields

### DIFF
--- a/src/main/java/com/facturador/ui/FacturacionFormController.java
+++ b/src/main/java/com/facturador/ui/FacturacionFormController.java
@@ -56,6 +56,10 @@ public class FacturacionFormController {
         detalleTable.setEditable(true);
 
         tipoComprobanteCombo.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> actualizarSerieYCorrelativo(newVal));
+
+        // Inicializar estado de campos de detracción
+        toggleDetraccion();
+        conDetraccionCheckBox.selectedProperty().addListener((obs, o, n) -> toggleDetraccion());
     }
 
     private void cargarCatalogos() {
@@ -118,11 +122,24 @@ public class FacturacionFormController {
         alert.showAndWait();
     }
 
+    @FXML
+    private void toggleDetraccion() {
+        boolean habilitar = conDetraccionCheckBox.isSelected();
+        codigoBienDetraccionField.setDisable(!habilitar);
+        porcentajeDetraccionField.setDisable(!habilitar);
+        montoDetraccionField.setDisable(!habilitar);
+        cuentaBancoNacionField.setDisable(!habilitar);
+        medioPagoDetraccionCombo.setDisable(!habilitar);
+        leyendaDetraccionField.setDisable(!habilitar);
+    }
+
     private void limpiarFormulario() {
         rucField.clear(); razonSocialField.clear(); direccionField.clear(); detalles.clear();
         subtotalLabel.setText("0.00"); igvLabel.setText("0.00"); totalLabel.setText("0.00");
-        totalTextoLabel.setText("SON: CERO CON 00/100 SOLES"); conDetraccionCheckBox.setSelected(false);
+        totalTextoLabel.setText("SON: CERO CON 00/100 SOLES");
+        conDetraccionCheckBox.setSelected(false);
         codigoBienDetraccionField.clear(); porcentajeDetraccionField.clear(); montoDetraccionField.clear(); cuentaBancoNacionField.clear(); leyendaDetraccionField.clear();
+        toggleDetraccion();
     }
 
     @FXML

--- a/src/main/resources/views/facturacion_form.fxml
+++ b/src/main/resources/views/facturacion_form.fxml
@@ -55,35 +55,36 @@
                         <Insets top="10" right="10" bottom="10" left="10"/>
                     </padding>
 
-                    <CheckBox fx:id="conDetraccionCheckBox" text="¿Aplica Detracción?" />
+                    <CheckBox fx:id="conDetraccionCheckBox" text="¿Aplica Detracción?" onAction="#toggleDetraccion" />
 
                     <HBox spacing="10">
                         <Label text="Bien o Servicio:"/>
-                        <TextField fx:id="codigoBienDetraccionField" promptText="Código de bien o servicio"/>
+                        <TextField fx:id="codigoBienDetraccionField" promptText="Código de bien o servicio" disable="true"/>
                     </HBox>
 
                     <HBox spacing="10">
                         <Label text="Porcentaje:"/>
-                        <TextField fx:id="porcentajeDetraccionField" promptText="Ej: 12.00"/>
+                        <TextField fx:id="porcentajeDetraccionField" promptText="Ej: 12.00" disable="true"/>
                         <Label text="Monto:"/>
-                        <TextField fx:id="montoDetraccionField" promptText="Ej: 150.00"/>
+                        <TextField fx:id="montoDetraccionField" promptText="Ej: 150.00" disable="true"/>
                     </HBox>
 
                     <HBox spacing="10">
                         <Label text="Cuenta Banco Nación:"/>
-                        <TextField fx:id="cuentaBancoNacionField" promptText="Ej: 00011223344"/>
+                        <TextField fx:id="cuentaBancoNacionField" promptText="Ej: 00011223344" disable="true"/>
                     </HBox>
 
                     <HBox spacing="10">
                         <Label text="Medio de Pago:"/>
-                        <ComboBox fx:id="medioPagoDetraccionCombo" promptText="Seleccione medio"/>
+                        <ComboBox fx:id="medioPagoDetraccionCombo" promptText="Seleccione medio" disable="true"/>
                     </HBox>
 
                     <HBox spacing="10">
                         <Label text="Leyenda SUNAT:"/>
                         <TextField fx:id="leyendaDetraccionField"
                                    promptText="Ej: Operación sujeta al Sistema de Pago..."
-                                   text="Operación sujeta al Sistema de Pago de Obligaciones Tributarias con el Gobierno Central"/>
+                                   text="Operación sujeta al Sistema de Pago de Obligaciones Tributarias con el Gobierno Central"
+                                   disable="true"/>
                     </HBox>
                 </VBox>
             </TitledPane>


### PR DESCRIPTION
## Summary
- disable detracción fields by default in the facturación form
- toggle detracción fields when the checkbox changes

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3a9c22d88332a5dbfaffc526167f