### PR TITLE
Fix Spanish words for numbers 21-29

### DIFF
--- a/src/main/java/com/facturador/util/NumeroALetrasUtil.java
+++ b/src/main/java/com/facturador/util/NumeroALetrasUtil.java
@@ -15,6 +15,12 @@ public class NumeroALetrasUtil {
             "OCHENTA", "NOVENTA"
     };
 
+    // Formas correctas para los números del 21 al 29
+    private static final String[] VEINTI_UNIDADES = {
+            "VEINTIUNO", "VEINTIDÓS", "VEINTITRÉS", "VEINTICUATRO", "VEINTICINCO",
+            "VEINTISÉIS", "VEINTISIETE", "VEINTIOCHO", "VEINTINUEVE"
+    };
+
     private static final String[] CENTENAS = {
             "", "CIENTO", "DOSCIENTOS", "TRESCIENTOS", "CUATROCIENTOS", "QUINIENTOS",
             "SEISCIENTOS", "SETECIENTOS", "OCHOCIENTOS", "NOVECIENTOS"
@@ -41,7 +47,11 @@ public class NumeroALetrasUtil {
             int decena = (int) (numero / 10);
             int unidad = (int) (numero % 10);
             if (numero <= 29) {
-                return DECENAS[decena] + UNIDADES[unidad].toLowerCase();
+                // Utilizar las formas especiales para el rango 21-29
+                if (numero >= 21) {
+                    return VEINTI_UNIDADES[(int) numero - 21];
+                }
+                return DECENAS[decena] + UNIDADES[unidad];
             } else {
                 return DECENAS[decena] + (unidad > 0 ? " Y " + UNIDADES[unidad] : "");
             }


### PR DESCRIPTION
## Summary
- handle special cases for numbers 21 through 29 in NumeroALetrasUtil

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ec1a70c833290316018509594d0