### PR TITLE
Fix KieSession names in DefaultKieSessionUtils

### DIFF
--- a/src/main/resources/rules/DefaultKieSessionUtils.java
+++ b/src/main/resources/rules/DefaultKieSessionUtils.java
@@ -10,10 +10,10 @@ public class DefaultKieSessionUtils {
             .newKieClasspathContainer();
 
     public static KieSession getEnrichRulesSession() {
-        return kc.newKieSession("enrich-session");
+        return kc.newKieSession("enrichRulesSession");
     }
 
     public static KieSession getSummaryRulesSession() {
-        return kc.newKieSession("summary-session");
+        return kc.newKieSession("summaryRulesSession");
     }
 }


### PR DESCRIPTION
## Summary
- use `enrichRulesSession` and `summaryRulesSession` when creating sessions
- clean up old session names

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a35f5e27483328f27627fa92a0a2d