### PR TITLE
Fix KieSession names

### DIFF
--- a/src/main/resources/rules/DefaultKieSessionUtils.java
+++ b/src/main/resources/rules/DefaultKieSessionUtils.java
@@ -10,10 +10,10 @@ public class DefaultKieSessionUtils {
             .newKieClasspathContainer();
 
     public static KieSession getEnrichRulesSession() {
-        return kc.newKieSession("enrich-session");
+        return kc.newKieSession("enrichRulesSession");
     }
 
     public static KieSession getSummaryRulesSession() {
-        return kc.newKieSession("summary-session");
+        return kc.newKieSession("summaryRulesSession");
     }
 }


### PR DESCRIPTION
## Summary
- correct KieSession names in DefaultKieSessionUtils

## Testing
- `grep -R "enrich-session" -n`
- `grep -R "summary-session" -n`


------
https://chatgpt.com/codex/tasks/task_e_684a370b96e0833290fd3ee06fd477d6