### PR TITLE
Make detraccion amount optional

### DIFF
--- a/src/main/java/com/facturador/sunat/mapper/MapperDtoToInvoice.java
+++ b/src/main/java/com/facturador/sunat/mapper/MapperDtoToInvoice.java
@@ -105,17 +105,20 @@ public class MapperDtoToInvoice {
         if (dto.isConDetraccion()
                 && dto.getCodigoBienDetraccion() != null && !dto.getCodigoBienDetraccion().isBlank()
                 && dto.getPorcentajeDetraccion() != null && dto.getPorcentajeDetraccion() > 0
-                && dto.getMontoDetraccion() != null && dto.getMontoDetraccion() > 0
                 && dto.getMedioPagoDetraccion() != null && !dto.getMedioPagoDetraccion().isBlank()
                 && dto.getCuentaBancoNacion() != null && !dto.getCuentaBancoNacion().isBlank()) {
 
-            builder.detraccion(Detraccion.builder()
+            Detraccion.DetraccionBuilder detraccion = Detraccion.builder()
                     .tipoBienDetraido(dto.getCodigoBienDetraccion())
                     .porcentaje(BigDecimal.valueOf(dto.getPorcentajeDetraccion()))
-                    .monto(BigDecimal.valueOf(dto.getMontoDetraccion()))
                     .medioDePago(dto.getMedioPagoDetraccion())
-                    .cuentaBancaria(dto.getCuentaBancoNacion())
-                    .build());
+                    .cuentaBancaria(dto.getCuentaBancoNacion());
+
+            if (dto.getMontoDetraccion() != null) {
+                detraccion.monto(BigDecimal.valueOf(dto.getMontoDetraccion()));
+            }
+
+            builder.detraccion(detraccion.build());
 
             if (dto.getLeyendaDetraccion() != null && !dto.getLeyendaDetraccion().isBlank()) {
                 builder.leyenda("2000", dto.getLeyendaDetraccion());


### PR DESCRIPTION
## Summary
- allow mapping detraccion without requiring an initial amount

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a39378dc48332a0ef31f29cbe2cb7