### PR TITLE
Handle detraccion payment fields

### DIFF
--- a/src/main/java/com/facturador/database/ComprobanteDAO.java
+++ b/src/main/java/com/facturador/database/ComprobanteDAO.java
@@ -30,6 +30,13 @@ public class ComprobanteDAO {
                 LocalDate fechaEmision = LocalDate.parse(rs.getString("fecha_emision"));
                 String estado = rs.getString("estado");
                 String direccion = rs.getString("direccion");
+                boolean conDetraccion = rs.getBoolean("con_detraccion");
+                String codigoBien = rs.getString("codigo_bien_detraccion");
+                Double porcentaje = rs.getObject("porcentaje_detraccion") != null ? rs.getDouble("porcentaje_detraccion") : null;
+                Double monto = rs.getObject("monto_detraccion") != null ? rs.getDouble("monto_detraccion") : null;
+                String cuentaBN = rs.getString("cuenta_bn");
+                String medioPagoDet = rs.getString("medio_pago_detraccion");
+                String leyendaDet = rs.getString("leyenda_detraccion");
 
                 // Carga de detalles asociados
                 List<ItemDetalle> detalles = obtenerDetallesPorComprobanteId(id);
@@ -49,6 +56,13 @@ public class ComprobanteDAO {
                 );
 
                 c.setEstado(estado);
+                c.setConDetraccion(conDetraccion);
+                c.setCodigoBienDetraccion(codigoBien);
+                c.setPorcentajeDetraccion(porcentaje);
+                c.setMontoDetraccion(monto);
+                c.setCuentaBancoNacion(cuentaBN);
+                c.setMedioPagoDetraccion(medioPagoDet);
+                c.setLeyendaDetraccion(leyendaDet);
                 lista.add(c);
             }
 

--- a/src/main/java/com/facturador/ui/FacturacionFormController.java
+++ b/src/main/java/com/facturador/ui/FacturacionFormController.java
@@ -218,7 +218,7 @@ public class FacturacionFormController {
 
         try (Connection conn = DatabaseConnection.getConnection()) {
             conn.setAutoCommit(false);
-            String sqlCab = "INSERT INTO comprobante (tipo_comprobante, serie, correlativo, fecha_emision, fecha_vencimiento, tipo_operacion, condicion_pago, metodo_pago, ruc_dni, razon_social, direccion, total, estado, con_detraccion, codigo_bien_detraccion, porcentaje_detraccion, monto_detraccion, cuenta_bn) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            String sqlCab = "INSERT INTO comprobante (tipo_comprobante, serie, correlativo, fecha_emision, fecha_vencimiento, tipo_operacion, condicion_pago, metodo_pago, ruc_dni, razon_social, direccion, total, estado, con_detraccion, codigo_bien_detraccion, porcentaje_detraccion, monto_detraccion, cuenta_bn, medio_pago_detraccion, leyenda_detraccion) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
             try (PreparedStatement pstmt = conn.prepareStatement(sqlCab, Statement.RETURN_GENERATED_KEYS)) {
                 pstmt.setString(1, comp.getTipoComprobante());
                 pstmt.setString(2, comp.getSerie());
@@ -238,6 +238,8 @@ public class FacturacionFormController {
                 pstmt.setDouble(16, comp.getPorcentajeDetraccion() != null ? comp.getPorcentajeDetraccion() : 0.0);
                 pstmt.setDouble(17, comp.getMontoDetraccion() != null ? comp.getMontoDetraccion() : 0.0);
                 pstmt.setString(18, comp.getCuentaBancoNacion());
+                pstmt.setString(19, comp.getMedioPagoDetraccion());
+                pstmt.setString(20, comp.getLeyendaDetraccion());
                 pstmt.executeUpdate();
 
                 ResultSet rs = pstmt.getGeneratedKeys();


### PR DESCRIPTION
## Summary
- persist medio_pago_detraccion and leyenda_detraccion when inserting comprobantes
- load detraccion payment fields in `ComprobanteDAO`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a393e581c8332bf9b12407385128c