### PR TITLE
Fix detraccion summary rule

### DIFF
--- a/src/main/resources/rules/summary/detraccion-summary.drl
+++ b/src/main/resources/rules/summary/detraccion-summary.drl
@@ -8,7 +8,8 @@ rule "Calcular monto de detracción"
 when
     $doc : Invoice(detraccion != null && totalImporte != null)
 then
-    BigDecimal porcentaje = $doc.getDetraccion().getPorcentaje();
+    BigDecimal porcentaje = $doc.getDetraccion().getPorcentaje()
+            .divide(new BigDecimal("100"));
     BigDecimal total = $doc.getTotalImporte().getImporteConImpuestos();
     BigDecimal monto = porcentaje.multiply(total).setScale(2, RoundingMode.HALF_EVEN);
     $doc.getDetraccion().setMonto(monto);


### PR DESCRIPTION
## Summary
- adjust `detraccion-summary.drl` so the percentage value is divided by 100 before calculating the amount

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3f3c430c8332a502368807c2e0d0